### PR TITLE
Fixes #11

### DIFF
--- a/gedit-markdown.sh
+++ b/gedit-markdown.sh
@@ -169,6 +169,8 @@ if [[ $1 == install ]]; then
 	mkdir -pv "$cheminTools"
 	cp -v tools/export-to-html "$cheminTools"
 	chmod +x "$cheminTools/export-to-html"
+	cp -v tools/export-to-pdf "$cheminTools"
+	chmod +x "$cheminTools/export-to-pdf"
 	
 	# Greffon «Aperçu Markdown».
 	cp -rv plugins/markdown-preview/* "$cheminPlugins"

--- a/tools/export-to-pdf
+++ b/tools/export-to-pdf
@@ -1,0 +1,28 @@
+#!/bin/bash
+# [Gedit Tool]
+# Name=Export to PDF
+# Shortcut=<Control><Alt>p
+# Languages=markdown
+# Applicability=all
+# Input=selection-document
+# Output=output-panel
+# Save-files=nothing
+
+# Verify that we have 'pandoc' installed
+command -v pandoc >/dev/null 2>&1 || 
+    { 
+        echo >&2 "I require Pandoc, but it's not installed. Aborting.";
+        echo >&2 "";
+
+        echo >&2 "Hint: 'sudo apt-get install pandoc texlive' should fix"; 
+        echo >&2 "       this for Ubuntu / Debian Linux"; 
+        exit 1;
+    }
+
+FILENAME=$GEDIT_CURRENT_DOCUMENT_NAME
+FILEPATH=$GEDIT_CURRENT_DOCUMENT_PATH
+
+NEW_FILENAME="${FILENAME%%.*}.pdf"
+echo "Exporting to $FILEPATH/$NEW_FILENAME"
+
+pandoc $FILENAME -o $NEW_FILENAME


### PR DESCRIPTION
This change introduces a new 'external tool' named 'Export to PDF'. Basically a
shell script that calls 'Pandoc' to convert the markdown file to PDF.

Also added a check to verify that we do have Pandoc installed.
